### PR TITLE
BZ1166209 - Data object show list does not allow a package filtering

### DIFF
--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/propertywindow.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/propertywindow.js
@@ -2999,6 +2999,8 @@ Ext.form.ComplexImportsField = Ext.extend(Ext.form.TriggerField,  {
                                     dataIndex: 'classname',
                                     editor: new Ext.form.ComboBox({
                                         id: 'customTypeCombo',
+                                        typeAhead: true,
+                                        anyMatch: true,
                                         valueField:'value',
                                         displayField:'name',
                                         labelStyle:'display:none',


### PR DESCRIPTION
This commit should enable the searching by content for the Defined Class Name in Imports Editor.