### PR TITLE
BZ1249559: Improve undo functionality in IE10 / IE11 by executing com…

### DIFF
--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Core/main.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Core/main.js
@@ -1019,10 +1019,11 @@ ORYX.Editor = {
 	/**
 	* Imports shapes in JSON as expected by {@link ORYX.Editor#loadSerialized}
 	* @param {Object|String} jsonObject The (serialized) json object to be imported
-	* @param {boolean } [noSelectionAfterImport=false] Set to true if no shapes should be selected after import
+	 * @param {boolean } [noSelectionAfterImport=false] Set to true if no shapes should be selected after import
+	 * @param {boolean } [returnCommandsWithoutExecute=false] Set to true if commands for importJSON should be returned without being executed
 	* @throws {SyntaxError} If the serialized json object contains syntax errors
 	*/
-	importJSON: function(jsonObject, noSelectionAfterImport) {
+	importJSON: function(jsonObject, noSelectionAfterImport, returnCommandsWithoutExecute) {
 		try {
 			jsonObject = this.renewResourceIds(jsonObject);
 		} catch(error){
@@ -1128,7 +1129,10 @@ ORYX.Editor = {
 											this.loadSerialized.bind(this),
 											noSelectionAfterImport,
 											this._getPluginFacade());
-			
+
+			if (returnCommandsWithoutExecute != undefined && returnCommandsWithoutExecute == true) {
+				return command;
+			}
 			this.executeCommands([command]);	
 			
 			return command.shapes.clone();

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/view.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/view.js
@@ -2139,9 +2139,10 @@ ORYX.Plugins.View = {
             var selection = this.facade.getSelection();
             var clipboard = new ORYX.Plugins.Edit.ClipBoard();
             clipboard.refresh(selection, this.getAllShapesToConsider(selection, true));
-            var command = new ORYX.Plugins.Edit.DeleteCommand(clipboard , this.facade);
-            this.facade.executeCommands([command]);
-            this.facade.importJSON(currentJSON);
+            var deleteCommand = new ORYX.Plugins.Edit.DeleteCommand(clipboard , this.facade);
+            var importJSONCommand = this.facade.importJSON(currentJSON, false, true);
+
+           this.facade.executeCommands([deleteCommand, importJSONCommand]);
 
            var foundShape = false;
            foundShape = this.findSelectedShape(options.shape, options);


### PR DESCRIPTION
…mands in refreshCanvasForIE as a group, rather than separately.

Tiho - will you take a look at this and see what you think. It improves the Undo functionality in IE10/IE11 to make it usable, but it's still not perfect. For each action that's been done in a process, the Undo command can be run twice - once to undo the selection of the selected activity, and once to undo the actual action that was done.