### PR TITLE
BZ-1257819 cherry-pick for 6.3.x

### DIFF
--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/query/FindDataTypesQuery.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/query/FindDataTypesQuery.java
@@ -28,7 +28,8 @@ import javax.inject.Named;
 
 import org.apache.lucene.search.Query;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.QueryBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.IndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.TypeIndexTerm;
@@ -73,7 +74,7 @@ public class FindDataTypesQuery implements NamedQuery {
             throw new IllegalArgumentException( "Required term has not been provided. Require '" + TypeIndexTerm.TERM + "'." );
         }
 
-        final QueryBuilder builder = new QueryBuilder();
+        final QueryBuilder builder = new BasicQueryBuilder();
         if ( useWildcards ) {
             builder.useWildcards();
         }


### PR DESCRIPTION
Bug 1257819 - GSS Rules are not populated in dropdown list in Test Scenarios in BRMS 6.1
Bug 1257817 - Rules are not populated in dropdown list in Test Scenarios in BRMS 6.1

The changes are 1:1 with what went into master.

Here are all the PRs that are related:
https://github.com/droolsjbpm/kie-wb-common/pull/121
https://github.com/droolsjbpm/drools-wb/pull/82
https://github.com/droolsjbpm/jbpm-designer/pull/70
https://github.com/droolsjbpm/jbpm-form-modeler/pull/19

