### PR TITLE
BZ1261829: Make DataIOEditor recognize datatypes entered manually

### DIFF
--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerPresenter.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerPresenter.java
@@ -328,6 +328,7 @@ public class DesignerPresenter
         }
 
         AssignmentData assignmentData = new AssignmentData(inputvars, outputvars, processvars, assignments, datatypes, disallowedpropertynames);
+        activityDataIOEditor.setAssignmentData(assignmentData);
         activityDataIOEditor.setDisallowedPropertyNames(assignmentData.getDisallowedPropertyNames());
         activityDataIOEditor.setInputAssignmentRows(assignmentData.getAssignmentRows(VariableType.INPUT));
         activityDataIOEditor.setOutputAssignmentRows(assignmentData.getAssignmentRows(VariableType.OUTPUT));

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/popup/ActivityDataIOEditorWidget.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/popup/ActivityDataIOEditorWidget.java
@@ -39,7 +39,7 @@ import org.jboss.errai.ui.client.widget.Table;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
-import org.jbpm.designer.client.popup.ActivityDataIOEditor.ListBoxValues;
+import org.jbpm.designer.client.util.ListBoxValues;
 import org.jbpm.designer.client.resources.i18n.DesignerEditorConstants;
 import org.jbpm.designer.client.shared.AssignmentRow;
 import org.jbpm.designer.client.shared.Variable.VariableType;

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/shared/AssignmentData.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/shared/AssignmentData.java
@@ -46,6 +46,7 @@ public class AssignmentData {
     private List<String> dataTypeDisplayNames = new ArrayList<String>();
     private Map<String, String> mapDisplayNameToDataType = new HashMap<String, String>();
     private Map<String, String> mapDataTypeToDisplayName = new HashMap<String, String>();
+    private Map<String, String> mapSimpleDataTypeToDisplayName = new HashMap<String, String>();
 
     private List<String> disallowedPropertyNames = new ArrayList<String>();
 
@@ -247,14 +248,16 @@ public class AssignmentData {
         this.dataTypeDisplayNames.clear();
         mapDisplayNameToDataType.clear();
         mapDataTypeToDisplayName.clear();
+        mapSimpleDataTypeToDisplayName.clear();
 
         if (dataTypes != null && !dataTypes.isEmpty()) {
             String[] dts = dataTypes.split(",");
             for (String dt : dts) {
                 dt = dt.trim();
-                if (!dt.isEmpty()) {
+                if (!dt.isEmpty() && !dt.startsWith("*")) {
                     String dtName = "";
                     String dtDisplayName = "";
+                    String dtSimpleType = "";
                     if (dt.contains(":")) {
                         dtDisplayName = dt.substring(0, dt.indexOf(':')).trim();
                         dtName = dt.substring(dt.indexOf(':') + 1).trim();
@@ -263,11 +266,20 @@ public class AssignmentData {
                         dtDisplayName = dt.trim();
                         dtName = dt.trim();
                     }
+                    if (dtDisplayName.indexOf(' ') > 0) {
+                        dtSimpleType = dtDisplayName.substring(0, dtDisplayName.indexOf(' '));
+                    }
+                    else {
+                        dtSimpleType = dtDisplayName;
+                    }
                     if (!dtName.isEmpty()) {
                         this.dataTypeDisplayNames.add(dtDisplayName);
                         this.dataTypes.add(dtName);
                         mapDisplayNameToDataType.put(dtDisplayName, dtName);
                         mapDataTypeToDisplayName.put(dtName, dtDisplayName);
+                    }
+                    if (!dtSimpleType.isEmpty()){
+                        mapSimpleDataTypeToDisplayName.put(dtSimpleType, dtDisplayName);
                     }
                 }
             }
@@ -279,6 +291,7 @@ public class AssignmentData {
         this.dataTypeDisplayNames.clear();
         mapDisplayNameToDataType.clear();
         mapDataTypeToDisplayName.clear();
+        mapSimpleDataTypeToDisplayName.clear();
 
         this.dataTypes = dataTypes;
         this.dataTypeDisplayNames = dataTypeDisplayNames;
@@ -384,6 +397,17 @@ public class AssignmentData {
         else {
             return dataType;
         }
+    }
+
+    public String getDataTypeDisplayNameForUserString(String userValue) {
+        if (mapDataTypeToDisplayName.containsKey(userValue)) {
+            return mapDataTypeToDisplayName.get(userValue);
+        }
+        else if (mapSimpleDataTypeToDisplayName.containsKey(userValue)) {
+            return mapSimpleDataTypeToDisplayName.get(userValue);
+        }
+
+        return null;
     }
 
     public String getDataTypesString() {

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/util/ListBoxValues.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/util/ListBoxValues.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.designer.client.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class containing a list of values for a ValueListBox<String>.
+ * This is used by the ListBoxes in the DataIOEditor to keep their drop-down lists
+ * up to date with updated with new values (CustomDataTypes / Constants) as
+ * the user adds them.
+ */
+public class ListBoxValues {
+    protected List<String> acceptableValuesWithCustomValues = new ArrayList<String>();
+    protected List<String> acceptableValuesWithoutCustomValues = new ArrayList<String>();
+    protected List<String> customValues = new ArrayList<String>();
+
+    protected String customPrompt;
+    protected String editPrefix;
+    public static final String EDIT_SUFFIX = " ...";
+
+    public interface ValueTester {
+        String getNonCustomValueForUserString(String userValue);
+    };
+
+    ValueTester valueTester = null;
+
+    public ListBoxValues(final String customPrompt, final String editPrefix, final ValueTester valueTester) {
+        this.customPrompt = customPrompt;
+        this.editPrefix = editPrefix;
+        this.valueTester = valueTester;
+    }
+
+    public String getEditPrefix()
+    {
+        return editPrefix;
+    }
+
+    public void addValues(List<String> acceptableValues) {
+        clear();
+        acceptableValuesWithoutCustomValues.addAll(acceptableValues);
+
+        acceptableValuesWithCustomValues.add("");
+        acceptableValuesWithCustomValues.add(customPrompt);
+        acceptableValuesWithCustomValues.addAll(acceptableValues);
+    }
+
+    public void addCustomValue(String newValue, String oldValue) {
+        if (oldValue != null && !oldValue.isEmpty())
+        {
+            if (acceptableValuesWithCustomValues.contains(oldValue)) {
+                acceptableValuesWithCustomValues.remove(oldValue);
+            }
+            if (customValues.contains(oldValue)) {
+                customValues.remove(oldValue);
+            }
+        }
+
+        if (newValue != null && !newValue.isEmpty()) {
+            if (!acceptableValuesWithCustomValues.contains(newValue)) {
+                int index = 1;
+                if (acceptableValuesWithCustomValues.size() < 1)
+                {
+                    index = acceptableValuesWithCustomValues.size();
+                }
+                acceptableValuesWithCustomValues.add(index, newValue);
+            }
+            if (!customValues.contains(newValue)) {
+                customValues.add(newValue);
+            }
+        }
+    }
+
+    public List<String> update(String currentValue) {
+        String currentEditValuePrompt = getEditValuePrompt(editPrefix);
+        String newEditValuePrompt = editPrefix + currentValue + EDIT_SUFFIX;
+        if (isCustomValue(currentValue)) {
+            if (newEditValuePrompt.equals(currentEditValuePrompt)) {
+                return acceptableValuesWithCustomValues;
+            }
+            if (currentEditValuePrompt != null) {
+                acceptableValuesWithCustomValues.remove(currentEditValuePrompt);
+            }
+            int editPromptIndex = acceptableValuesWithCustomValues.indexOf(currentValue);
+            if (editPromptIndex > -1) {
+                editPromptIndex++;
+            }
+            else if (acceptableValuesWithCustomValues.size() > 1) {
+                editPromptIndex = 2;
+            }
+            else {
+                editPromptIndex = acceptableValuesWithCustomValues.size();
+            }
+            acceptableValuesWithCustomValues.add(editPromptIndex, newEditValuePrompt);
+        }
+        else if (currentEditValuePrompt != null) {
+            acceptableValuesWithCustomValues.remove(currentEditValuePrompt);
+        }
+        return acceptableValuesWithCustomValues;
+   }
+
+    public List<String> getAcceptableValuesWithCustomValues() {
+        return acceptableValuesWithCustomValues;
+    }
+    public List<String> getAcceptableValuesWithoutCustomValues() {
+        return acceptableValuesWithoutCustomValues;
+    }
+
+    public boolean isCustomValue(String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        else {
+            return customValues.contains(value);
+        }
+    }
+
+    protected void clear() {
+        customValues.clear();
+        acceptableValuesWithCustomValues.clear();
+        acceptableValuesWithoutCustomValues.clear();
+    }
+
+    protected String getEditValuePrompt(String editPrefix) {
+        if (acceptableValuesWithCustomValues.size() > 0) {
+            for (int i = 0; i < acceptableValuesWithCustomValues.size(); i++) {
+                String value = acceptableValuesWithCustomValues.get(i);
+                if (value.startsWith(editPrefix)) {
+                    return value;
+                }
+            }
+        }
+        return null;
+    }
+
+    public String getNonCustomValueForUserString(String userValue) {
+        if (valueTester != null) {
+            return valueTester.getNonCustomValueForUserString(userValue);
+        }
+        else {
+            return null;
+        }
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("acceptableValuesWithoutCustomValues:\n");
+        for (String value : acceptableValuesWithoutCustomValues) {
+            sb.append('\t').append(value).append(",\n");
+        }
+        sb.append('\n');
+        sb.append("acceptableValuesWithCustomValues:\n");
+        for (String value : acceptableValuesWithCustomValues) {
+            sb.append('\t').append(value).append(",\n");
+        }
+        return sb.toString();
+    }
+}

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/util/ListBoxValuesTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/util/ListBoxValuesTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.designer.client.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jbpm.designer.client.resources.i18n.DesignerEditorConstants;
+import org.jbpm.designer.client.shared.AssignmentData;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ListBoxValuesTest {
+
+    /**
+     * General test for adding custom values to ProcessVar ListBoxValues
+     */
+    @Test
+    public void testProcessVarListBoxValues() {
+        List<String> processVarStartValues = Arrays.asList(
+                "** Variable Definitions **", "employee",  "reason", "performance"
+        );
+
+        ListBoxValues processVarValues = new ListBoxValues("Constant ...", "Edit ", null);
+        processVarValues.addValues(processVarStartValues);
+        processVarValues.addCustomValue("\"abc\"", "");
+        processVarValues.update("\"abc\"");
+        processVarValues.update("reason");
+        processVarValues.addCustomValue("\"ghi\"", "");
+        processVarValues.update("\"ghi\"");
+        processVarValues.addCustomValue("\"def\"", "\"ghi\"");
+        processVarValues.update("\"def\"");
+        processVarValues.update("reason");
+        // Add Constant with same value as a ProcessVar
+        processVarValues.addCustomValue("\"employee\"", "");
+        processVarValues.update("\"employee\"");
+        processVarValues.update("performance");
+        processVarValues.addCustomValue("123", "");
+        processVarValues.update("123");
+        processVarValues.update("\"reason\"");
+        processVarValues.addCustomValue("\"jkl\"", "\"reason\"");
+        processVarValues.update("\"jkl\"");
+
+        System.out.println(processVarValues.toString());
+
+        String[] acceptableValuesWithoutCustomValues = {
+                "** Variable Definitions **",
+                "employee",
+                "reason",
+                "performance"
+        };
+
+        String[] expectedAcceptableValuesWithCustomValues = {
+                "",
+                "\"jkl\"",
+                "Edit \"jkl\" ...",
+                "123",
+                "\"employee\"",
+                "\"def\"",
+                "\"abc\"",
+                "Constant ...",
+                "** Variable Definitions **",
+                "employee",
+                "reason",
+                "performance"
+        };
+
+        assertArrayEquals(acceptableValuesWithoutCustomValues, processVarValues.getAcceptableValuesWithoutCustomValues().toArray());
+        assertArrayEquals(expectedAcceptableValuesWithCustomValues, processVarValues.getAcceptableValuesWithCustomValues().toArray());
+    }
+
+    /**
+     * General test for adding custom values to DataTypes ListBoxValues
+     */
+    String sDataTypes1 = "String:String, Integer:Integer, Boolean:Boolean, Float:Float, Object:Object, ******:******,UserCommand [org.jbpm.examples.cmd]:org.jbpm.examples.cmd.UserCommand,User [org.jbpm.examples.data]:org.jbpm.examples.data.User,Invoice [org.kie.test]:org.kie.test.Invoice,InvoiceLine [org.kie.test]:org.kie.test.InvoiceLine,PositionTest1 [org.kie.test]:org.kie.test.PositionTest1,PositionTest2 [org.kie.test]:org.kie.test.PositionTest2,PositionTest3 [org.kie.test]:org.kie.test.PositionTest3,PositionTest5 [org.kie.test]:org.kie.test.PositionTest5,SubComponent [org.kie.test]:org.kie.test.SubComponent,TestFormulas [org.kie.test]:org.kie.test.TestFormulas,TestPatterns [org.kie.test]:org.kie.test.TestPatterns,TestTypes [org.kie.test]:org.kie.test.TestTypes,TestTypesLine [org.kie.test]:org.kie.test.TestTypesLine";
+    AssignmentData assignmentData1 = new AssignmentData(null, null, null, null, sDataTypes1, null);
+    @Test
+    public void testDataTypeListBoxValues() {
+
+        ListBoxValues dataTypeValues = new ListBoxValues("Custom ...", "Edit ",
+                new ListBoxValues.ValueTester() {
+                    public String getNonCustomValueForUserString(String userValue) {
+                        if (assignmentData1 != null) {
+                            return assignmentData1.getDataTypeDisplayNameForUserString(userValue);
+                        }
+                        else {
+                            return null;
+                        }
+                    }
+                });
+
+        dataTypeValues.addValues(assignmentData1.getDataTypeDisplayNames());
+        dataTypeValues.addCustomValue("com.test.MyType", "");
+        dataTypeValues.update("com.test.MyType");
+        dataTypeValues.update("String");
+        dataTypeValues.addCustomValue("com.test.YourType", "String");
+        dataTypeValues.update("com.test.YourType");
+        // Get known type for SimpleType entered by user
+        String nonCustomValue = dataTypeValues.getNonCustomValueForUserString("InvoiceLine");
+        dataTypeValues.update(nonCustomValue);
+        dataTypeValues.addCustomValue("com.test.HisType", "");
+        dataTypeValues.update("com.test.HisType");
+
+        System.out.println(dataTypeValues.toString());
+
+        String[] acceptableValuesWithoutCustomValues = {
+                "String",
+                "Integer",
+                "Boolean",
+                "Float",
+                "Object",
+                "UserCommand [org.jbpm.examples.cmd]",
+                "User [org.jbpm.examples.data]",
+                "Invoice [org.kie.test]",
+                "InvoiceLine [org.kie.test]",
+                "PositionTest1 [org.kie.test]",
+                "PositionTest2 [org.kie.test]",
+                "PositionTest3 [org.kie.test]",
+                "PositionTest5 [org.kie.test]",
+                "SubComponent [org.kie.test]",
+                "TestFormulas [org.kie.test]",
+                "TestPatterns [org.kie.test]",
+                "TestTypes [org.kie.test]",
+                "TestTypesLine [org.kie.test]"
+
+        };
+
+        String[] expectedAcceptableValuesWithCustomValues = {
+                "",
+                "com.test.HisType",
+                "Edit com.test.HisType ...",
+                "com.test.YourType",
+                "com.test.MyType",
+                "Custom ...",
+                "Integer",
+                "Boolean",
+                "Float",
+                "Object",
+                "UserCommand [org.jbpm.examples.cmd]",
+                "User [org.jbpm.examples.data]",
+                "Invoice [org.kie.test]",
+                "InvoiceLine [org.kie.test]",
+                "PositionTest1 [org.kie.test]",
+                "PositionTest2 [org.kie.test]",
+                "PositionTest3 [org.kie.test]",
+                "PositionTest5 [org.kie.test]",
+                "SubComponent [org.kie.test]",
+                "TestFormulas [org.kie.test]",
+                "TestPatterns [org.kie.test]",
+                "TestTypes [org.kie.test]",
+                "TestTypesLine [org.kie.test]"
+
+        };
+
+        assertArrayEquals(acceptableValuesWithoutCustomValues, dataTypeValues.getAcceptableValuesWithoutCustomValues().toArray());
+        assertArrayEquals(expectedAcceptableValuesWithCustomValues, dataTypeValues.getAcceptableValuesWithCustomValues().toArray());
+    }
+
+
+}


### PR DESCRIPTION
The commit includes refactoring of the ListBoxValues class to enable addition of unit tests.
More refactoring of the DataIOEditor classes with unit tests will follow in subsequent PR's.