### PR TITLE
BZ 1277522 - Opening Process Sources twice breaks the modal

### DIFF
--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/view.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/view.js
@@ -1922,7 +1922,11 @@ ORYX.Plugins.View = {
                     var winWidth = Math.min(600, visibleWidth * 2/3);
                     var winHeight = Math.min(550, visibleHeight * 2/3);
 
-                    var win = new Ext.Window({
+                    if(this.sourcewin != null && this.sourcewin !== undefined) {
+                        this.sourcewin.destroy();
+                    }
+
+                    this.sourcewin = new Ext.Window({
                         width:winWidth,
                         id:'processSources',
                         height:winHeight,
@@ -1931,9 +1935,14 @@ ORYX.Plugins.View = {
                         items: [sourcesPanel],
                         tbar: [
                             dlBPMN2Button
-                        ]
+                        ],
+                        listeners:{
+                            hide: function(){
+                                this.sourcewin.destroy();
+                            }.bind(this)
+                        }
                     });
-                    win.show();
+                    this.sourcewin.show();
                     this.bpmn2FoldFunc = CodeMirror.newFoldFunction(CodeMirror.tagRangeFinder);
                     var bpmn2SourceEditor = CodeMirror.fromTextArea(document.getElementById("bpmnSourceTextArea"), {
                         mode: "application/xml",


### PR DESCRIPTION
@jlindop - can you please test? Link to BZ https://bugzilla.redhat.com/show_bug.cgi?id=1277522
To reproduce open process, select view process sources and *without* closing the first source window open another one then click+drag it around -- there should not be another blue box appearing behind it from the first window (which is now being destroyed). 

Yes no test and yes I am almost done with adding test framework for JS.