### PR TITLE
bz1289575: Improve error handling in TransformerServlet.doPost in cas…

### DIFF
--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/server/TransformerServlet.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/server/TransformerServlet.java
@@ -126,6 +126,10 @@ public class TransformerServlet extends HttpServlet {
         String sourceEnc = req.getParameter("enc");
         String convertServiceTasks = req.getParameter("convertservicetasks");
 
+        if (transformto == null || transformto.isEmpty()) {
+            _logger.error("Invalid request: missing \"transformto\" parameter. You may need to increase max-post-size for the server's http connector.");
+        }
+
         String formattedSvg = ( formattedSvgEncoded == null ? "" : new String(Base64.decodeBase64(formattedSvgEncoded), "UTF-8") );
         //formattedSvg = URLDecoder.decode(formattedSvg, "UTF-8");
         String rawSvg = ( rawSvgEncoded == null ? "" : new String(Base64.decodeBase64(rawSvgEncoded), "UTF-8") );


### PR DESCRIPTION
…e payload is too long

When the user tries to download a PDF or image for a very large process, an error is now reported.

If you're running business-central in EAP standalone, the fix for this is to edit standalone-full.xml, adding the property  max-post-size="0" to
<connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"

@tsurdilo  will you review this - if you can think of a better error message, that would be fine.