### PR TITLE
Increase memory for GWT compiler to 2g in full profile

### DIFF
--- a/jbpm-designer-standalone/pom.xml
+++ b/jbpm-designer-standalone/pom.xml
@@ -892,7 +892,7 @@
               <!-- Build all GWT permutations and optimize them -->
               <module>org.jbpm.designer.jBPMDesigner</module>
               <draftCompile>false</draftCompile>
-              <extraJvmArgs>-Xms512m -Xmx1024m -Xss1M</extraJvmArgs>
+              <extraJvmArgs>-Xms1g -Xmx2g -Xss1M</extraJvmArgs>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Needed to fix a failing build, as the original 1g is not enough anymore.