### PR TITLE
Increase -Xmx Jvm parameter to enable -Dfull compilation

### DIFF
--- a/jbpm-designer-standalone/pom.xml
+++ b/jbpm-designer-standalone/pom.xml
@@ -892,7 +892,7 @@
               <!-- Build all GWT permutations and optimize them -->
               <module>org.jbpm.designer.jBPMDesigner</module>
               <draftCompile>false</draftCompile>
-              <extraJvmArgs>-Xms512m -Xmx1024m -Xss1M</extraJvmArgs>
+              <extraJvmArgs>-Xms512m -Xmx2048m -Xss1M</extraJvmArgs>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Compilation of jbpm-designer-standalone with -Dfull option was failing with Out of Memory error.