### PR TITLE
BZ 1314510 - process model image shows the node in waiting status grey instead of red after sending a signal event

### DIFF
--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/activenodeshighlighter.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/activenodeshighlighter.js
@@ -16,21 +16,25 @@ ORYX.Plugins.ActiveNodesHighlighter = Clazz.extend({
         }).bind(this));
     },
     applyHighlightingToChild: function(child) {
-        if(ORYX.ACTIVENODES) {
-            for(var i=0;i<ORYX.ACTIVENODES.length;i++) {
-                if(child instanceof ORYX.Core.Node || child instanceof ORYX.Core.Edge) {
-                    if(ORYX.ACTIVENODES[i] == child.resourceId) {
-                        child.setProperty("oryx-bordercolor", "#FF0000");
-                    }
-                }
-            }
-        }
         if(ORYX.COMPLETEDNODES) {
             for(var i=0;i<ORYX.COMPLETEDNODES.length;i++) {
                 if(child instanceof ORYX.Core.Node || child instanceof ORYX.Core.Edge) {
                     if(ORYX.COMPLETEDNODES[i] == child.resourceId) {
                         child.setProperty("oryx-bordercolor", "#A8A8A8");
                         child.setProperty("oryx-bgcolor", "#CDCDCD");
+                    }
+                }
+            }
+        }
+
+        if(ORYX.ACTIVENODES) {
+            for(var i=0;i<ORYX.ACTIVENODES.length;i++) {
+                if(child instanceof ORYX.Core.Node || child instanceof ORYX.Core.Edge) {
+                    if(ORYX.ACTIVENODES[i] == child.resourceId) {
+                        child.setProperty("oryx-bordercolor", "#FF0000");
+                        // in case of looping current active node can have been completed before
+                        // soo reset background color from grey
+                        child.setProperty("oryx-bgcolor", child.properties["oryx-origbgcolor"]);
                     }
                 }
             }


### PR DESCRIPTION
@jlindop this is how to test (you must test this inside the workbench, not designer standalone)

1. create new process and use following bpmn2 for test: http://pastebin.com/u6h6FMGB
2. Save process and generate all forms (important)
3. Build and deploy project
4. Go to process management and start instance of this process
5. on the process start form select the "loop" checkbox
6. Signal the process (signal name is "test")
7. View the process instance view (designer in readonly mode)
8. The signal node should be highlighted as active (See http://imgur.com/E5tA82P)

Before this change the signal node after the signal which triggers the loop was grey and not "active"