### PR TITLE
JBPM-5035 Replaced System.lineSeparator method call

### DIFF
--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnitCommonTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnitCommonTest.java
@@ -23,7 +23,7 @@ public class JbpmPreprocessingUnitCommonTest {
     @Test
     public void testReadFile() throws IOException {
         String result = JbpmPreprocessingUnit.readFile(FILE_NAME);
-        assertEquals(FILE_CONTENT + System.lineSeparator(), result);
+        assertEquals(FILE_CONTENT + System.getProperty("line.separator"), result);
     }
 
     @Test


### PR DESCRIPTION
- This is relevant only for 6.4.x branch, because on master it's expected that it supports jdk 1.8 and up. 