### PR TITLE
BZ1269969: Fix restore BP functionality

### DIFF
--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerPresenter.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerPresenter.java
@@ -598,7 +598,7 @@ public class DesignerPresenter
 
     }
 
-    private void setup( Map<String, String> editorParameters,
+    protected void setup( Map<String, String> editorParameters,
                         String editorID,
                         Overview overview ) {
 
@@ -608,9 +608,7 @@ public class DesignerPresenter
 
             resetEditorPages( overview );
 
-            if ( editorParameters.containsKey( "readonly" ) ) {
-                isReadOnly = Boolean.valueOf( editorParameters.get( "readonly" ) );
-            }
+            editorParameters.put("readonly", Boolean.toString(isReadOnly));
 
             designerEditorParametersPublisher.publish( editorParameters );
 

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Core/main.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Core/main.js
@@ -104,7 +104,7 @@ ORYX.Editor = {
 			model = config.model;
 		}
 
-        this.updateViewLockState();
+        this.updateViewLockState(false);
 
         if(config.error) {
             Ext.Msg.show({
@@ -178,7 +178,7 @@ ORYX.Editor = {
 		}.bind(this), 200);
 	},
 
-	updateViewLockState: function() {
+	updateViewLockState: function(canReload) {
 		if(ORYX.INSTANCE_VIEW_MODE != true) {
 			if ( (typeof parent.isLocked === "function") && (typeof parent.isLockedByCurrentUser === "function") ) {
 				var isEditorLocked = parent.isLocked();
@@ -196,7 +196,7 @@ ORYX.Editor = {
 				}
 
 				// We're in read only mode, but got the lock, so let's reload to enter edit mode.
-				if (isReadOnly && !ORYX.VIEWLOCKED) {
+				if (isReadOnly && !ORYX.VIEWLOCKED && canReload) {
 					if (typeof parent.reload === "function") {
 						ORYX.PROCESS_SAVED = true;
 						parent.reload();

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/saveplugin.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/saveplugin.js
@@ -176,7 +176,7 @@ ORYX.Plugins.SavePlugin = Clazz.extend({
             if (this.editorLocked && !parent.isLockedByCurrentUser()) {
                 this.editorLocked = false;
             } else if (!this.editorLocked && !parent.isLocked()) {
-                ORYX.EDITOR.updateViewLockState();
+                ORYX.EDITOR.updateViewLockState(true);
             }
         }
     },
@@ -184,7 +184,7 @@ ORYX.Plugins.SavePlugin = Clazz.extend({
     setUnsaved: function() {
         ORYX.PROCESS_SAVED = false;
         
-        ORYX.EDITOR.updateViewLockState();
+        ORYX.EDITOR.updateViewLockState(true);
                         
         if(!this.editorLocked) {            
             if ( typeof parent.acquireLock === "function" ) {
@@ -432,7 +432,7 @@ ORYX.Plugins.SavePlugin = Clazz.extend({
     },
 
     saveSync : function() {
-        ORYX.EDITOR.updateViewLockState();
+        ORYX.EDITOR.updateViewLockState(false);
 
         // the view-locked-by-current-user logic is already determined by updateViewLockState so here if viewlocked is true we are sure its locked by some other user and not us
         if(!ORYX.PROCESS_SAVED && ORYX.VIEWLOCKED != true) {
@@ -564,7 +564,7 @@ ORYX.Plugins.SavePlugin = Clazz.extend({
 
 
     unloadWindow: function() {
-        this.saveSync(false);
+        this.saveSync();
     },
     clearCanvas: function() {
         ORYX.EDITOR.getCanvas().nodes.each(function(node) {

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/DesignerPresenterTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/DesignerPresenterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.designer.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.jbpm.designer.client.parameters.DesignerEditorParametersPublisher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DesignerPresenterTest {
+
+    @Mock
+    private DesignerView view;
+
+    @Mock
+    private Overview overview;
+
+    @Mock
+    private DesignerEditorParametersPublisher designerEditorParametersPublisher;
+
+    @Spy
+    private Map<String, String> parameters = new HashMap<String, String>();
+
+    @InjectMocks
+    @Spy
+    private DesignerPresenter presenter =  new DesignerPresenter(view)
+    {
+        @Override
+        protected void resetEditorPages(final Overview overview)
+        {
+        }
+    };
+
+    @Test
+    public void testSetup() {
+        String id = "testId";
+
+        presenter.setup(parameters, id, overview);
+
+        verify(parameters, times(1)).put("readonly", "false");
+        verify(designerEditorParametersPublisher, times(1)).publish(parameters);
+        verify(view, times(1)).setup(id, parameters);
+
+        assertEquals(1, parameters.size());
+        assertTrue(parameters.containsKey("readonly"));
+    }
+}


### PR DESCRIPTION
The use-cases in Comments 10 & 11 of https://bugzilla.redhat.com/show_bug.cgi?id=1269969 should both not be reproducible any more. (On master, the use-case in comment 10 worked even before this PR).
The case in Comment 11 cannot be reproduced any more because when the user selects a previous version in the Overview tab, the version is opened in read-only mode (whereas previously it was editable).

This PR also fixes the problem where if you select a previous version of a BP, then hit "Restore", the "Restore" button didn't change back to "Save".

@Tiho - testing this PR should include testing that the locking functionality works when two different users have the same BP open.