### PR TITLE
JBPM-4979 - Generated PDF is unreadable - update: pdf generation enabled via system property

### DIFF
--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/server/EditorHandler.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/server/EditorHandler.java
@@ -85,6 +85,8 @@ public class EditorHandler extends HttpServlet {
      */
     public static final String USEOLDDATAASSIGNMENTS = "designer.useolddataassignments";
 
+    public static final String SHOW_PDF_DOC = "designer.showpdfdoc";
+
     public static final String PRESET_PERSPECTIVE = "org.jbpm.designer.perspective";
 
     /**
@@ -111,6 +113,11 @@ public class EditorHandler extends HttpServlet {
      * The designer use old data assignments setting.
      */
     private boolean _useOldDataAssignments;
+
+    /**
+     * Show / Hide PDF Documentation display option
+     */
+    private boolean showPDFDoc;
 
     /**
      * The designer preprocess mode setting.
@@ -180,7 +187,7 @@ public class EditorHandler extends HttpServlet {
         _preProcess = Boolean.parseBoolean(System.getProperty(PREPROCESS) == null ? config.getInitParameter(PREPROCESS) : System.getProperty(PREPROCESS));
         _skin = System.getProperty(SKIN) == null ? config.getInitParameter(SKIN) : System.getProperty(SKIN);
         _designerVersion = readDesignerVersion(config.getServletContext());
-
+        showPDFDoc = doShowPDFDoc(config);
 
         String editor_file = config.
                 getServletContext().getRealPath(designer_path + "editor.st");
@@ -338,6 +345,7 @@ public class EditorHandler extends HttpServlet {
         editorTemplate.add("localhistoryenabled", profile.getLocalHistoryEnabled());
         editorTemplate.add("localhistorytimeout", profile.getLocalHistoryTimeout());
         editorTemplate.add("designerversion", _designerVersion);
+        editorTemplate.add("showpdfdoc", showPDFDoc);
         editorTemplate.add("storesvgonsave", profile.getStoreSVGonSaveOption());
         editorTemplate.add("defaultSkin", designer_path + "css/theme-default.css");
         editorTemplate.add("presetperspective", System.getProperty(PRESET_PERSPECTIVE) == null ? "" : System.getProperty(PRESET_PERSPECTIVE));
@@ -464,5 +472,9 @@ public class EditorHandler extends HttpServlet {
         } finally {
             scanner.close();
         }
+    }
+
+    public boolean doShowPDFDoc(ServletConfig config) {
+        return Boolean.parseBoolean(System.getProperty(SHOW_PDF_DOC) == null ? config.getInitParameter(SHOW_PDF_DOC) : System.getProperty(SHOW_PDF_DOC));
     }
 }

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/editorhandler/EditorHandlerBaseTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/editorhandler/EditorHandlerBaseTest.java
@@ -17,6 +17,8 @@
 package org.jbpm.designer.editorhandler;
 
 import org.jbpm.designer.helper.TestHttpServletRequest;
+import org.jbpm.designer.helper.TestServletConfig;
+import org.jbpm.designer.helper.TestServletContext;
 import org.jbpm.designer.repository.Repository;
 import org.jbpm.designer.repository.RepositoryBaseTest;
 import org.jbpm.designer.repository.VFSFileSystemProducer;
@@ -26,13 +28,28 @@ import org.jbpm.designer.web.profile.impl.JbpmProfileImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.servlet.ServletConfig;
+
+
 import static junit.framework.Assert.assertEquals;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
 public class EditorHandlerBaseTest extends RepositoryBaseTest {
+
+    private static Boolean showPDFAnswer;
 
     @Before
     public void setup() {
@@ -71,5 +88,40 @@ public class EditorHandlerBaseTest extends RepositoryBaseTest {
 
         params.remove("instanceviewmode");
         assertEquals(editorHandler.getInstanceViewMode(new TestHttpServletRequest(params)), "false");
+    }
+
+    @Test
+    public void testDoShowPDFDoc() throws Exception {
+        try {
+            Repository repository = new VFSRepository(producer.getIoService());
+            ((VFSRepository)repository).setDescriptor(descriptor);
+            profile.setRepository(repository);
+
+            final EditorHandler editorHandler = new EditorHandler();
+
+            TestServletConfig config = new TestServletConfig(new TestServletContext(repository));
+
+            // no init parameter set and no system property set
+            assertFalse(editorHandler.doShowPDFDoc(config));
+
+            // init parameter set and no system property set
+            config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "false");
+            assertFalse(editorHandler.doShowPDFDoc(config));
+
+            config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "true");
+            assertTrue(editorHandler.doShowPDFDoc(config));
+
+            // system property overwrites config init parameter
+            config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "true");
+            System.setProperty(EditorHandler.SHOW_PDF_DOC, "false");
+            assertFalse(editorHandler.doShowPDFDoc(config));
+
+            config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "false");
+            System.setProperty(EditorHandler.SHOW_PDF_DOC, "true");
+            assertTrue(editorHandler.doShowPDFDoc(config));
+        } finally {
+            // clear system property for other tests
+            System.clearProperty(EditorHandler.SHOW_PDF_DOC);
+        }
     }
 }

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/helper/TestServletConfig.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/helper/TestServletConfig.java
@@ -36,7 +36,7 @@ public class TestServletConfig implements ServletConfig {
     }
 
     public String getInitParameter(String name) {
-        return null;  
+        return servletContext.getInitParameter(name);
     }
 
     public Enumeration getInitParameterNames() {

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/helper/TestServletContext.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/helper/TestServletContext.java
@@ -30,10 +30,7 @@ import javax.servlet.descriptor.JspConfigDescriptor;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.EventListener;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class TestServletContext implements ServletContext {
 
@@ -42,6 +39,8 @@ public class TestServletContext implements ServletContext {
     public TestServletContext() {
 
     }
+
+    Map<String, String> initParameters = new HashMap<String, String>();
 
     public TestServletContext(Repository repository) {
         this.repository = repository;
@@ -130,7 +129,7 @@ public class TestServletContext implements ServletContext {
     }
 
     public String getInitParameter(String name) {
-        return null;
+        return initParameters.get(name);
     }
 
     public Enumeration getInitParameterNames() {
@@ -140,7 +139,8 @@ public class TestServletContext implements ServletContext {
     @Override
     public boolean setInitParameter( String name,
                                      String value ) {
-        return false;
+        initParameters.put(name, value);
+        return true;
     }
 
     public Object getAttribute(String name) {

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/editor.st
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/editor.st
@@ -22,6 +22,7 @@
         ORYX.READONLY = $readonly$;
         ORYX.VIEWLOCKED = $viewlocked$;
         ORYX.USEOLDDATAASSIGNMENTS = $useolddataassignments$;
+        ORYX.SHOWPDFDOC = $showpdfdoc$;
 
         ORYX.LOCAL_HISTORY_ENABLED = $localhistoryenabled$;
         ORYX.LOCAL_HISTORY_TIMEOUT = $localhistorytimeout$;

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/processdoc/default.jsp
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/processdoc/default.jsp
@@ -62,9 +62,9 @@
         </div>
         <div class="col-sm-9">
             <p><div id="pagebuttons" class="well noprint" align="right">
-                <button type="button" class="btn btn-default btn-sm" onclick="createDocsPNG()">Doc PNG</button>&nbsp;&nbsp;
-                <button type="button" class="btn btn-default btn-sm" onclick="showAsPDF()">PDF</button>&nbsp;&nbsp;
-                <button type="buton" class="btn btn-default btn-sm" onclick="window.print();">Print</button>
+                <button type="button" id="docspngbutton" class="btn btn-default btn-sm" onclick="createDocsPNG()">Doc PNG</button>&nbsp;&nbsp;
+                <button type="button" id="docspdfbutton" class="btn btn-default btn-sm" onclick="showAsPDF()">PDF</button>&nbsp;&nbsp;
+                <button type="button" id="docsprintbutton" class="btn btn-default btn-sm" onclick="window.print();">Print</button>
             </div></p>
 
             <div id="pagecontainercore">
@@ -228,6 +228,13 @@
 
 <script>
     function showProcessDocs() {
+        // show or hide pdf doc generation button
+        if(parent.ORYX.SHOWPDFDOC && parent.ORYX.SHOWPDFDOC == true) {
+            $("#docspdfbutton").show();
+        } else {
+            $("#docspdfbutton").hide();
+        }
+
         var processJSON = parent.ORYX.EDITOR.getSerializedJSON();
         var processDataTotals = {
             "processdatatotals":[


### PR DESCRIPTION
in the process documentation tab the "PDF" button is now disabled by default. To enabled it use startup parameter:

./standalone.sh -Ddesigner.showpdfdoc=true