### PR TITLE
RHBPMS-4011: Fix i18n Simulation problem in IE11

### DIFF
--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/simulation.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/simulation.js
@@ -524,9 +524,11 @@ ORYX.Plugins.Simulation = Clazz.extend({
 				            success: function(response) {
 				    	   		try {
 				    	   			if(response.responseText && response.responseText.length > 0 && response.status == 200) {
+				    	   				// RHBPMS-4011 - white space must be removed for atob in IE11
+				    	   				var responseText = response.responseText.replace(/\s/g, '');
 				    	   				this.facade.raiseEvent({
 				    	   		            type: ORYX.CONFIG.EVENT_SIMULATION_SHOW_RESULTS,
-				    	   		            results: decodeURIComponent(window.atob(response.responseText))
+				    	   		            results: decodeURIComponent(window.atob(responseText))
 				    	   		        });
 				    	   			} else {
                                            this.facade.raiseEvent({


### PR DESCRIPTION
Note: RHBPMS-4011 has the flags for release in 6.3.1.

To test, I do a mvn -Dfull build of jbpm-designer, and a mvn -Dfull build of kie-wb-distributions/kie-wb (which takes a while), then run the kie-wb-6.4.1-SNAPSHOT-eap6_4.war in EAP and test from IE11 on Windows 7.