### PR TITLE
JBPM-5153 SimulationServletTest.testLocalizedStartEndTime fails on some JDKs

### DIFF
--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/server/SimulationServletTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/server/SimulationServletTest.java
@@ -16,7 +16,6 @@
 
 package org.jbpm.designer.web.server;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -132,7 +131,7 @@ public class SimulationServletTest {
         assertNotNull(encodedResponseText);
         String responseText = UriUtils.decode(new String(Base64.decodeBase64(encodedResponseText), "UTF-8"));
         assertNotNull(responseText);
-        assertTrue(responseText.contains("мая"));
+        assertTrue(responseText.contains("май") || responseText.contains("мая"));
         assertTrue(responseText.contains("июн"));
     }
 


### PR DESCRIPTION
- Fixed testLocalizedStartEndTime test.

I tried changing the language, but didn't find any that match the needs of this test (non latin, not changing months on different JDKs)