### PR TITLE
RHBPMS-4034: Show default gateway name:id in combo after reselection …

### DIFF
--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/propertywindow.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/propertywindow.js
@@ -1018,11 +1018,11 @@ ORYX.Plugins.PropertyWindow = {
                                             var csobj = gatewayconnectionsJson[i];
 											this.getSequenceFlowNameForID(csobj.sequenceflowinfo);
 											if(this.presInfo && this.presInfo.length > 0) {
-												this.presInfo = this.presInfo + ":" + csobj.sequenceflowinfo;
+												this.presInfo = this.presInfo + " : " + csobj.sequenceflowinfo;
 											} else {
 												this.presInfo = csobj.sequenceflowinfo;
 											}
-                                            options.push(["", this.presInfo, csobj.sequenceflowinfo]);
+                                            options.push(["", this.presInfo, this.presInfo]);
                                         }
                                     } else {
                                         ORYX.EDITOR._pluginFacade.raiseEvent({


### PR DESCRIPTION
…in properties view

@tsurdilo  This makes sure the default gateway "name : id" is shown in the combo after the user selects a default gateway, clicks away from the gateway, then selects the gateway again.