### PR TITLE
JBPM-5152: Fix cherry-pick to 6.5.x (https://github.com/droolsjbpm/jb…

### DIFF
--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/popup/ActivityDataIOEditorWidgetViewImpl.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/popup/ActivityDataIOEditorWidgetViewImpl.java
@@ -58,12 +58,6 @@ public class ActivityDataIOEditorWidgetViewImpl extends Composite implements Act
     private HeadingElement tabletitle = Document.get().createHElement(3);
 
     @DataField
-    protected TableCellElement nameth = Document.get().createTHElement();
-
-    @DataField
-    protected TableCellElement datatypeth = Document.get().createTHElement();
-
-    @DataField
     private final TableCellElement processvarorconstantth = Document.get().createTHElement();
 
     /**

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/popup/ActivityDataIOEditorWidgetViewImplTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/popup/ActivityDataIOEditorWidgetViewImplTest.java
@@ -52,12 +52,6 @@ public class ActivityDataIOEditorWidgetViewImplTest {
     @GwtMock
     private Button button;
 
-    @Mock
-    private TableCellElement nameth;
-
-    @Mock
-    private TableCellElement datatypeth;
-
     @GwtMock
     private ListWidget<AssignmentRow, AssignmentListItemWidgetViewImpl> assignments;
 
@@ -80,8 +74,6 @@ public class ActivityDataIOEditorWidgetViewImplTest {
         view = GWT.create(ActivityDataIOEditorWidgetViewImpl.class);
         view.assignments = assignments;
         view.addVarButton = button;
-        view.nameth = nameth;
-        view.datatypeth = datatypeth;
         view.notification = notification;
 
         doCallRealMethod().when(view).setAssignmentRows(any(List.class));


### PR DESCRIPTION
…pm-designer/pull/367/commits/93f90afb8992b44ab0afc3795b7a1d7098240ba7)

The cherry-pick stopped designer from opening because code in ActivityDataIOEditorWidgetViewImpl.java referenced DataFields which don't exist in the ActivityDataIOEditorWidget.html template on 6.5.x.