### PR TITLE
[6.5.x] JBPM-5278: added tests and refactoring done

### DIFF
--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnit.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnit.java
@@ -708,16 +708,20 @@ public class JbpmPreprocessingUnit implements IDiagramPreprocessingUnit {
                 List<String> toInstallTasks = Arrays.asList(defaultServiceRepoTasks.split("\\s*,\\s*"));
                 for(String installTask : toInstallTasks) {
                     if(workitemsFromRepo.containsKey(installTask)) {
-                        ServiceRepoUtils.installWorkItem(workitemsFromRepo,
-                                installTask,
-                                uuid,
-                                repository,
-                                vfsService,
-                                workitemInstalledEventEvent,
-                                notification,
-                                pomService,
-                                projectService,
-                                metadataService);
+                        try {
+                            ServiceRepoUtils.installWorkItem(workitemsFromRepo,
+                                    installTask,
+                                    uuid,
+                                    repository,
+                                    vfsService,
+                                    workitemInstalledEventEvent,
+                                    notification,
+                                    pomService,
+                                    projectService,
+                                    metadataService);
+                        } catch (Exception e) {
+                            _logger.error("Work Item '" + installTask + "' was not installed correctly: " + e.getMessage());
+                        }
                     }
                 }
             }

--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/server/ServiceRepoUtils.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/server/ServiceRepoUtils.java
@@ -81,7 +81,7 @@ public class ServiceRepoUtils {
 
         repository.createAsset(widAssetBuilder.getAsset());
 
-        if(iconName != null) {
+        if(iconName != null && !iconName.isEmpty()) {
             AssetBuilder iconAssetBuilder = AssetBuilderFactory.getAssetBuilder(Asset.AssetType.Byte);
             String iconExtension = iconName.substring(iconName.lastIndexOf(".") + 1);
             String iconFileName = iconName.substring(0, iconName.lastIndexOf("."));

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/editorhandler/EditorHandlerBaseTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/editorhandler/EditorHandlerBaseTest.java
@@ -23,17 +23,17 @@ import org.jbpm.designer.repository.Repository;
 import org.jbpm.designer.repository.RepositoryBaseTest;
 import org.jbpm.designer.repository.vfs.VFSRepository;
 import org.jbpm.designer.server.EditorHandler;
+import org.jbpm.designer.web.preprocessing.IDiagramPreprocessingService;
 import org.jbpm.designer.web.profile.IDiagramProfileService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
+import org.mockito.*;
 import org.mockito.runners.MockitoJUnitRunner;
 
 
+import javax.servlet.ServletConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -43,6 +43,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 
+import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,27 +53,38 @@ public class EditorHandlerBaseTest extends RepositoryBaseTest {
     @Mock
     IDiagramProfileService profileService;
 
+    @Mock
+    IDiagramPreprocessingService preprocessingService;
+
+    private Repository repository;
+
     @Spy
     @InjectMocks
     private EditorHandler editorHandler = new EditorHandler();
+
+    @Captor
+    private ArgumentCaptor<String> stringCaptor;
 
     @Before
     public void setup() {
         super.setup();
         when(profileService.findProfile(any(HttpServletRequest.class), anyString())).thenReturn(profile);
+
+        repository = new VFSRepository(producer.getIoService());
+        ((VFSRepository)repository).setDescriptor(descriptor);
+        profile.setRepository(repository);
     }
 
     @After
     public void teardown() {
         super.teardown();
+        System.clearProperty(EditorHandler.SHOW_PDF_DOC);
+        System.clearProperty(EditorHandler.SERVICE_REPO);
+        System.clearProperty(EditorHandler.SERVICE_REPO_TASKS);
     }
 
     @Test
     public void testGetInstanceViewMode() throws Exception {
-        Repository repository = new VFSRepository(producer.getIoService());
-        ((VFSRepository)repository).setDescriptor(descriptor);
-        profile.setRepository(repository);
-
         Map<String, String> params = new HashMap<String, String>();
         params.put("instanceviewmode", "false");
 
@@ -87,35 +99,28 @@ public class EditorHandlerBaseTest extends RepositoryBaseTest {
 
     @Test
     public void testDoShowPDFDoc() throws Exception {
-        try {
-            Repository repository = new VFSRepository(producer.getIoService());
-            ((VFSRepository)repository).setDescriptor(descriptor);
-            profile.setRepository(repository);
 
-            TestServletConfig config = new TestServletConfig(new TestServletContext(repository));
+        TestServletConfig config = new TestServletConfig(new TestServletContext(repository));
 
-            // no init parameter set and no system property set
-            assertFalse(editorHandler.doShowPDFDoc(config));
+        // no init parameter set and no system property set
+        assertFalse(editorHandler.doShowPDFDoc(config));
 
-            // init parameter set and no system property set
-            config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "false");
-            assertFalse(editorHandler.doShowPDFDoc(config));
+        // init parameter set and no system property set
+        config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "false");
+        assertFalse(editorHandler.doShowPDFDoc(config));
 
-            config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "true");
-            assertTrue(editorHandler.doShowPDFDoc(config));
+        config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "true");
+        assertTrue(editorHandler.doShowPDFDoc(config));
 
-            // system property overwrites config init parameter
-            config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "true");
-            System.setProperty(EditorHandler.SHOW_PDF_DOC, "false");
-            assertFalse(editorHandler.doShowPDFDoc(config));
+        // system property overwrites config init parameter
+        config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "true");
+        System.setProperty(EditorHandler.SHOW_PDF_DOC, "false");
+        assertFalse(editorHandler.doShowPDFDoc(config));
 
-            config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "false");
-            System.setProperty(EditorHandler.SHOW_PDF_DOC, "true");
-            assertTrue(editorHandler.doShowPDFDoc(config));
-        } finally {
-            // clear system property for other tests
-            System.clearProperty(EditorHandler.SHOW_PDF_DOC);
-        }
+        config.getServletContext().setInitParameter(EditorHandler.SHOW_PDF_DOC, "false");
+        System.setProperty(EditorHandler.SHOW_PDF_DOC, "true");
+        assertTrue(editorHandler.doShowPDFDoc(config));
+
     }
 
     @Test
@@ -139,5 +144,52 @@ public class EditorHandlerBaseTest extends RepositoryBaseTest {
             // exception thrown due to mocked request and response
         }
         verify(profileService, never()).findProfile(any(HttpServletRequest.class), anyString());
+    }
+
+    @Test
+    public void testServiceRepoAndTaskSystem() throws Exception {
+        System.setProperty(EditorHandler.SERVICE_REPO, "service repo");
+        System.setProperty(EditorHandler.SERVICE_REPO_TASKS, "taskA,taskB");
+        TestServletConfig config = new TestServletConfig(new TestServletContext(repository));
+
+        verifyServiceRepoAndTasks(config, true);
+    }
+
+    @Test
+    public void testServiceRepoAndTaskServlet() throws Exception {
+        TestServletContext context = new TestServletContext(repository);
+        context.setInitParameter(EditorHandler.SERVICE_REPO, "service repo");
+        context.setInitParameter(EditorHandler.SERVICE_REPO_TASKS, "taskA,taskB");
+        TestServletConfig config = new TestServletConfig(context);
+
+        verifyServiceRepoAndTasks(config, true);
+    }
+
+    @Test
+    public void testServiceRepoAndTaskEmpty() throws Exception {
+        TestServletConfig config = new TestServletConfig(new TestServletContext(repository));
+        verifyServiceRepoAndTasks(config, false);
+    }
+
+    private void verifyServiceRepoAndTasks(ServletConfig config, boolean present) throws Exception {
+        PrintWriter writer = mock(PrintWriter.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getWriter()).thenReturn(writer);
+
+        editorHandler.init(config);
+        editorHandler.doGet(mock(HttpServletRequest.class),response);
+
+        verify(writer).write(stringCaptor.capture());
+
+        if(present) {
+            assertTrue(stringCaptor.getValue().contains("ORYX.SERVICE_REPO = \"service repo\";"));
+            assertTrue(stringCaptor.getValue().contains("ORYX.SERVICE_REPO_TASKS"));
+            assertTrue(stringCaptor.getValue().contains("\"name\" : \"taskA\""));
+            assertTrue(stringCaptor.getValue().contains("\"name\" : \"taskB\""));
+        } else {
+            assertTrue(stringCaptor.getValue().contains("ORYX.SERVICE_REPO = \"\";"));
+            assertFalse(stringCaptor.getValue().contains("\"name\" : \"taskA\""));
+            assertFalse(stringCaptor.getValue().contains("\"name\" : \"taskB\""));
+        }
     }
 }

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnitVFSTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnitVFSTest.java
@@ -15,41 +15,75 @@
 
 package org.jbpm.designer.web.preprocessing.impl;
 
+import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.service.POMService;
+import org.guvnor.common.services.project.service.ProjectService;
+import org.guvnor.common.services.shared.metadata.MetadataService;
 import org.jbpm.designer.helper.TestHttpServletRequest;
 import org.jbpm.designer.helper.TestIDiagramProfile;
 import org.jbpm.designer.helper.TestServletContext;
+import org.jbpm.designer.notification.DesignerWorkitemInstalledEvent;
 import org.jbpm.designer.repository.Asset;
 import org.jbpm.designer.repository.AssetBuilderFactory;
 import org.jbpm.designer.repository.Repository;
 import org.jbpm.designer.repository.RepositoryBaseTest;
+import org.jbpm.designer.repository.filters.FilterByExtension;
 import org.jbpm.designer.repository.impl.AssetBuilder;
 import org.jbpm.designer.repository.vfs.VFSRepository;
+import org.jbpm.designer.server.EditorHandler;
+import org.jbpm.designer.web.server.ServiceRepoUtilsTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.VFSService;
+import org.uberfire.workbench.events.NotificationEvent;
+
+
+import javax.enterprise.event.Event;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@RunWith(MockitoJUnitRunner.class)
 public class JbpmPreprocessingUnitVFSTest extends RepositoryBaseTest {
+
+    @Mock
+    private Event<DesignerWorkitemInstalledEvent> workitemInstalledEvent;
+
+    @Mock
+    private Event<NotificationEvent> notificationEvent;
+
+    @Mock
+    private POMService pomService;
+
+    @Mock
+    private ProjectService<? extends Project> projectService;
+
+    @Mock
+    private MetadataService metadataService;
+
+    private JbpmPreprocessingUnit preprocessingUnitVFS;
+
+    private Repository repository;
+
+    private String uniqueId;
+
+    private Map<String, String> params;
 
 
     @Before
     public void setup() {
         super.setup();
-    }
 
-    @After
-    public void teardown() {
-        super.teardown();
-    }
-    @Test
-    public void testProprocess() {
-        Repository repository = new VFSRepository(producer.getIoService());
+        repository = new VFSRepository(producer.getIoService());
         ((VFSRepository)repository).setDescriptor(descriptor);
         profile.setRepository(repository);
+
         //prepare folders that will be used
         repository.createDirectory("/myprocesses");
         repository.createDirectory("/global");
@@ -60,16 +94,28 @@ public class JbpmPreprocessingUnitVFSTest extends RepositoryBaseTest {
                 .type("bpmn2")
                 .name("process")
                 .location("/myprocesses");
-        String uniqueId = repository.createAsset(builder.getAsset());
+        uniqueId = repository.createAsset(builder.getAsset());
 
         // create instance of preprocessing unit
-        JbpmPreprocessingUnit preprocessingUnitVFS = new JbpmPreprocessingUnit(new TestServletContext(), "/", null, null, null, null, null, null);
+         preprocessingUnitVFS = new JbpmPreprocessingUnit(new TestServletContext(), "/", Mockito.mock(VFSService.class),
+                                                            workitemInstalledEvent, notificationEvent,
+                                                            pomService, projectService, metadataService);
+
 
         // setup parameters
-        Map<String, String> params = new HashMap<String, String>();
+        params = new HashMap<String, String>();
         params.put("uuid", uniqueId);
+    }
 
-        // run preprocess
+    @After
+    public void teardown() {
+        super.teardown();
+        System.clearProperty(EditorHandler.SERVICE_REPO);
+        System.clearProperty(EditorHandler.SERVICE_REPO_TASKS);
+    }
+    @Test
+    public void testPreprocess() {
+
         preprocessingUnitVFS.preprocess(new TestHttpServletRequest(params), null, new TestIDiagramProfile(repository), null, false, false, null, null);
 
         // validate results
@@ -115,4 +161,105 @@ public class JbpmPreprocessingUnitVFSTest extends RepositoryBaseTest {
         repository.assetExists("/myprocesses/process.bpmn2");
 
     }
+
+    @Test
+    public void testInstallDefaultWids() throws Exception{
+        System.setProperty(EditorHandler.SERVICE_REPO, ServiceRepoUtilsTest.class.getResource("servicerepo").toURI().toString());
+        System.setProperty(EditorHandler.SERVICE_REPO_TASKS, "SwitchYardService,Rewardsystem");
+
+        // run preprocess
+        preprocessingUnitVFS.preprocess(new TestHttpServletRequest(params), null, new TestIDiagramProfile(repository), null, false, false, null, null);
+
+        verifyWidsPngsAndGifs(Arrays.asList("/myprocesses/WorkDefinitions.wid", "/myprocesses/SwitchYardService.wid", "/myprocesses/Rewardsystem.wid"),
+                Arrays.asList("/myprocesses/defaultservicenodeicon.png"),
+                Arrays.asList("/myprocesses/switchyard.gif", "/myprocesses/defaultemailicon.gif", "/myprocesses/defaultlogicon.gif"));
+
+        Mockito.verify(workitemInstalledEvent, Mockito.times(2)).fire(Matchers.any(DesignerWorkitemInstalledEvent.class));
+    }
+
+    @Test
+    public void testInstallNoServiceRepo() throws Exception{
+        System.setProperty(EditorHandler.SERVICE_REPO_TASKS, "SwitchYardService,Rewardsystem");
+
+        // run preprocess
+        preprocessingUnitVFS.preprocess(new TestHttpServletRequest(params), null, new TestIDiagramProfile(repository), null, false, false, null, null);
+
+        verifyWidsPngsAndGifs(Arrays.asList("/myprocesses/WorkDefinitions.wid"),
+                            Arrays.asList("/myprocesses/defaultservicenodeicon.png"),
+                            Arrays.asList("/myprocesses/defaultemailicon.gif", "/myprocesses/defaultlogicon.gif"));
+
+        Mockito.verify(workitemInstalledEvent, Mockito.never()).fire(Matchers.any(DesignerWorkitemInstalledEvent.class));
+    }
+
+    @Test
+    public void testInstallNoServiceTasks() throws Exception{
+        System.setProperty(EditorHandler.SERVICE_REPO, ServiceRepoUtilsTest.class.getResource("servicerepo").toURI().toString());
+
+        // run preprocess
+        preprocessingUnitVFS.preprocess(new TestHttpServletRequest(params), null, new TestIDiagramProfile(repository), null, false, false, null, null);
+
+        verifyWidsPngsAndGifs(Arrays.asList("/myprocesses/WorkDefinitions.wid"),
+                            Arrays.asList("/myprocesses/defaultservicenodeicon.png"),
+                            Arrays.asList("/myprocesses/defaultemailicon.gif", "/myprocesses/defaultlogicon.gif"));
+
+        Mockito.verify(workitemInstalledEvent, Mockito.never()).fire(Matchers.any(DesignerWorkitemInstalledEvent.class));
+    }
+
+    @Test
+    public void testInstallNotExistingTask() throws Exception{
+        System.setProperty(EditorHandler.SERVICE_REPO, ServiceRepoUtilsTest.class.getResource("servicerepo").toURI().toString());
+        System.setProperty(EditorHandler.SERVICE_REPO_TASKS, "NonExistingTask");
+
+        // run preprocess
+        preprocessingUnitVFS.preprocess(new TestHttpServletRequest(params), null, new TestIDiagramProfile(repository), null, false, false, null, null);
+
+        verifyWidsPngsAndGifs(Arrays.asList("/myprocesses/WorkDefinitions.wid"),
+                            Arrays.asList("/myprocesses/defaultservicenodeicon.png"),
+                            Arrays.asList("/myprocesses/defaultemailicon.gif", "/myprocesses/defaultlogicon.gif"));
+
+        Mockito.verify(workitemInstalledEvent, Mockito.never()).fire(Matchers.any(DesignerWorkitemInstalledEvent.class));
+    }
+
+    @Test
+    public void testInstallTwice() throws Exception{
+        System.setProperty(EditorHandler.SERVICE_REPO, ServiceRepoUtilsTest.class.getResource("servicerepo").toURI().toString());
+        System.setProperty(EditorHandler.SERVICE_REPO_TASKS, "MicrosoftAcademy");
+
+        // run preprocess twice
+        preprocessingUnitVFS.preprocess(new TestHttpServletRequest(params), null, new TestIDiagramProfile(repository), null, false, false, null, null);
+        preprocessingUnitVFS.preprocess(new TestHttpServletRequest(params), null, new TestIDiagramProfile(repository), null, false, false, null, null);
+
+        verifyWidsPngsAndGifs(Arrays.asList("/myprocesses/WorkDefinitions.wid","/myprocesses/MicrosoftAcademy.wid" ),
+                                Arrays.asList("/myprocesses/microsoftacademy.png", "/myprocesses/defaultservicenodeicon.png"),
+                                Arrays.asList("/myprocesses/defaultemailicon.gif", "/myprocesses/defaultlogicon.gif"));
+
+        Mockito.verify(workitemInstalledEvent, Mockito.times(2)).fire(Matchers.any(DesignerWorkitemInstalledEvent.class));
+    }
+
+    private void verifyWidsPngsAndGifs(List<String> wids, List<String> pngs, List<String> gifs) {
+        if(wids != null) {
+            Collection<Asset> storedWids = repository.listAssetsRecursively("/", new FilterByExtension("wid"));
+            assertEquals(wids.size(), storedWids.size());
+            for (String wid : wids) {
+                repository.assetExists(wid);
+            }
+        }
+
+        if(pngs != null) {
+            Collection<Asset> storedPngs = repository.listAssetsRecursively("/", new FilterByExtension("png"));
+            assertEquals(pngs.size(), storedPngs.size());
+            for (String png : pngs) {
+                repository.assetExists(png);
+            }
+        }
+
+        if(gifs != null) {
+            Collection<Asset> storedGifs = repository.listAssetsRecursively("/", new FilterByExtension("gif"));
+            assertEquals(gifs.size(), storedGifs.size());
+            for (String gif : gifs) {
+                repository.assetExists(gif);
+            }
+        }
+    }
+
 }

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/server/JbpmServiceRepositoryServletTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/server/JbpmServiceRepositoryServletTest.java
@@ -37,9 +37,28 @@ import static org.junit.Assert.assertNotNull;
 
 public class JbpmServiceRepositoryServletTest extends RepositoryBaseTest {
 
+    private Repository repository;
+
+    private String uniqueId;
+
+    private Map<String, String> params;
+
     @Before
     public void setup() {
         super.setup();
+
+        repository = new VFSRepository(producer.getIoService());
+        ((VFSRepository)repository).setDescriptor(descriptor);
+        profile.setRepository(repository);
+
+        AssetBuilder builder = AssetBuilderFactory.getAssetBuilder(Asset.AssetType.Text);
+        builder.content("bpmn2 content")
+                .type("bpmn2")
+                .name("samplebpmn2process")
+                .location("/defaultPackage");
+        uniqueId = repository.createAsset(builder.getAsset());
+
+        params = new HashMap<String, String>();
     }
 
     @After
@@ -49,11 +68,6 @@ public class JbpmServiceRepositoryServletTest extends RepositoryBaseTest {
 
     @Test
     public void testDisplayRepoContent() throws Exception {
-        Repository repository = new VFSRepository(producer.getIoService());
-        ((VFSRepository)repository).setDescriptor(descriptor);
-        profile.setRepository(repository);
-
-        Map<String, String> params = new HashMap<String, String>();
         params.put("repourl", getClass().getResource("servicerepo").toURI().toString());
         params.put("profile", "jbpm");
         params.put("action", "display");
@@ -88,20 +102,24 @@ public class JbpmServiceRepositoryServletTest extends RepositoryBaseTest {
     }
 
     @Test
+    public void testDisplayEmptyRepoContent() throws Exception {
+        params.put("repourl", getClass().getResource("emptyservicerepo").toURI().toString());
+        params.put("profile", "jbpm");
+        params.put("action", "display");
+
+        TestHttpServletResponse testResponse = new TestHttpServletResponse();
+
+        JbpmServiceRepositoryServlet jbpmServiceRepositoryServlet = new JbpmServiceRepositoryServlet();
+        jbpmServiceRepositoryServlet.setProfile(profile);
+        jbpmServiceRepositoryServlet.init(new TestServletConfig(new TestServletContext(repository)));
+        jbpmServiceRepositoryServlet.doPost(new TestHttpServletRequest(params), testResponse);
+
+        assertEquals("false", new String(testResponse.getContent()));
+    }
+
+    @Test
     public void testInstallWid() throws Exception {
 
-        Repository repository = new VFSRepository(producer.getIoService());
-        ((VFSRepository)repository).setDescriptor(descriptor);
-        profile.setRepository(repository);
-        AssetBuilder builder = AssetBuilderFactory.getAssetBuilder(Asset.AssetType.Text);
-        builder.content("bpmn2 content")
-                .type("bpmn2")
-                .name("samplebpmn2process")
-                .location("/defaultPackage");
-        String uniqueId = repository.createAsset(builder.getAsset());
-
-        // setup parameters
-        Map<String, String> params = new HashMap<String, String>();
         params.put("repourl", getClass().getResource("servicerepo").toURI().toString());
         params.put("asset", "Rewardsystem");
         params.put("profile", "jbpm");
@@ -122,18 +140,7 @@ public class JbpmServiceRepositoryServletTest extends RepositoryBaseTest {
 
     @Test
     public void testInstallInvalidWid() throws Exception {
-        Repository repository = new VFSRepository(producer.getIoService());
-        ((VFSRepository)repository).setDescriptor(descriptor);
-        profile.setRepository(repository);
-        AssetBuilder builder = AssetBuilderFactory.getAssetBuilder(Asset.AssetType.Text);
-        builder.content("bpmn2 content")
-                .type("bpmn2")
-                .name("samplebpmn2process")
-                .location("/defaultPackage");
-        String uniqueId = repository.createAsset(builder.getAsset());
 
-        // setup parameters
-        Map<String, String> params = new HashMap<String, String>();
         params.put("repourl", getClass().getResource("servicerepo").toURI().toString());
         params.put("asset", "InvalidService");
         params.put("profile", "jbpm");
@@ -149,5 +156,48 @@ public class JbpmServiceRepositoryServletTest extends RepositoryBaseTest {
         assertEquals(1, repository.listAssetsRecursively("/", new FilterByExtension("bpmn2")).size());
         assertEquals(0, repository.listAssetsRecursively("/", new FilterByExtension("wid")).size());
         assertEquals(0, repository.listAssetsRecursively("/", new FilterByExtension("png")).size());
+    }
+
+    @Test
+    public void testInstallWidTwice() throws Exception {
+
+        // setup parameters
+        params.put("repourl", getClass().getResource("servicerepo").toURI().toString());
+        params.put("asset", "MicrosoftAcademy");
+        params.put("profile", "jbpm");
+        params.put("category", "Search");
+        params.put("action", "install");
+        params.put("uuid", uniqueId);
+
+        JbpmServiceRepositoryServlet jbpmServiceRepositoryServlet = new JbpmServiceRepositoryServlet();
+        jbpmServiceRepositoryServlet.setProfile(profile);
+        jbpmServiceRepositoryServlet.init(new TestServletConfig(new TestServletContext(repository)));
+
+        jbpmServiceRepositoryServlet.doPost(new TestHttpServletRequest(params), new TestHttpServletResponse());
+        jbpmServiceRepositoryServlet.doPost(new TestHttpServletRequest(params), new TestHttpServletResponse());
+
+        assertEquals(1, repository.listAssetsRecursively("/", new FilterByExtension("bpmn2")).size());
+        assertEquals(1, repository.listAssetsRecursively("/", new FilterByExtension("wid")).size());
+        assertEquals(1, repository.listAssetsRecursively("/", new FilterByExtension("png")).size());
+    }
+
+    @Test
+    public void testInstallWidEmptyRepository() throws Exception {
+
+        // setup parameters
+        params.put("repourl", getClass().getResource("emptyservicerepo").toURI().toString());
+        params.put("asset", "MicrosoftAcademy");
+        params.put("profile", "jbpm");
+        params.put("category", "Search");
+        params.put("action", "install");
+        params.put("uuid", uniqueId);
+
+        JbpmServiceRepositoryServlet jbpmServiceRepositoryServlet = new JbpmServiceRepositoryServlet();
+        jbpmServiceRepositoryServlet.setProfile(profile);
+        jbpmServiceRepositoryServlet.init(new TestServletConfig(new TestServletContext(repository)));
+
+        TestHttpServletResponse response = new TestHttpServletResponse();
+        jbpmServiceRepositoryServlet.doPost(new TestHttpServletRequest(params), response);
+        assertEquals("false", new String(response.getContent()));
     }
 }

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/server/JbpmServiceRepositoryServletTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/server/JbpmServiceRepositoryServletTest.java
@@ -83,7 +83,7 @@ public class JbpmServiceRepositoryServletTest extends RepositoryBaseTest {
         assertNotNull(response);
         JSONObject json = new JSONObject(response);
         assertNotNull(json);
-        assertEquals(3, json.length());
+        assertEquals(4, json.length());
         JSONArray maArray = (JSONArray) json.get("MicrosoftAcademy");
         assertNotNull(maArray);
         assertEquals(9, maArray.length());
@@ -94,11 +94,15 @@ public class JbpmServiceRepositoryServletTest extends RepositoryBaseTest {
         assertEquals(9, syArray.length());
         assertEquals("SwitchYardService", syArray.get(0));
 
+        JSONArray minimalisticArray = (JSONArray) json.get("Minimalistic");
+        assertNotNull(minimalisticArray);
+        assertEquals(9, minimalisticArray.length());
+        assertEquals("Minimalistic", minimalisticArray.get(0));
+
         JSONArray rsArray = (JSONArray) json.get("Rewardsystem");
         assertNotNull(rsArray);
         assertEquals(9, rsArray.length());
         assertEquals("Rewardsystem", rsArray.get(0));
-
     }
 
     @Test

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/server/ServiceRepoUtilsTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/web/server/ServiceRepoUtilsTest.java
@@ -56,10 +56,9 @@ import java.util.Map;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ServiceRepoUtilsTest extends RepositoryBaseTest {
@@ -88,6 +87,7 @@ public class ServiceRepoUtilsTest extends RepositoryBaseTest {
     protected Event<NotificationEvent> notification = mock(EventSourceMock.class);
 
     private final List<Object> receivedWidInstallEvents = new ArrayList<Object>();
+
     private Event<DesignerWorkitemInstalledEvent> widinstall = new EventSourceMock<DesignerWorkitemInstalledEvent>() {
 
         @Override
@@ -96,6 +96,12 @@ public class ServiceRepoUtilsTest extends RepositoryBaseTest {
         }
 
     };
+
+    private Repository repository;
+
+    private String uuid;
+
+    private POM projectPOM;
 
 
     @Before
@@ -111,16 +117,7 @@ public class ServiceRepoUtilsTest extends RepositoryBaseTest {
             }
         });
 
-    }
-
-    @After
-    public void teardown() {
-        super.teardown();
-    }
-
-    @Test
-    public void testInstallWorkitem() throws Exception {
-        Repository repository = new VFSRepository(producer.getIoService());
+        repository = new VFSRepository(producer.getIoService());
         ((VFSRepository)repository).setDescriptor(descriptor);
         profile.setRepository(repository);
 
@@ -148,7 +145,7 @@ public class ServiceRepoUtilsTest extends RepositoryBaseTest {
 
         Path rootPath = Paths.convert(((VFSRepository) repository).getDescriptor().getRepositoryRootPath());
 
-        String uuid = rootPath.toURI() + "/src/main/resources/samplebpmn2process.bpmn2";
+        uuid = rootPath.toURI() + "/src/main/resources/samplebpmn2process.bpmn2";
         String pomuuid = rootPath.toURI() + "/pom.xml";
 
         KieProject project = Mockito.mock(KieProject.class);
@@ -159,11 +156,21 @@ public class ServiceRepoUtilsTest extends RepositoryBaseTest {
         when( pomXmlPath.toURI() ).thenReturn(pomuuid);
         when(project.getPomXMLPath() ).thenReturn( pomXmlPath );
 
-        POM projectPOM = new POM();
+        projectPOM = new POM();
         when( pomService.load(pomXmlPath) ).thenReturn(projectPOM);
 
         when(ioService.exists(any(org.uberfire.java.nio.file.Path.class))).thenReturn(true);
         when(projectService.resolveProject(any(Path.class))).thenReturn(project);
+
+    }
+
+    @After
+    public void teardown() {
+        super.teardown();
+    }
+
+    @Test
+    public void testInstallWorkitem() throws Exception {
 
         Map<String, WorkDefinitionImpl> workitemsFromRepo = WorkItemRepository.getWorkDefinitions(getClass().getResource("servicerepo").toURI().toString());
 
@@ -201,12 +208,12 @@ public class ServiceRepoUtilsTest extends RepositoryBaseTest {
         assertTrue(event instanceof DesignerWorkitemInstalledEvent);
         DesignerWorkitemInstalledEvent eventReceived = (DesignerWorkitemInstalledEvent) event;
         assertEquals("Rewardsystem", eventReceived.getName());
-        assertEquals("mvel: com.rewardsystem.MyRewardsHandler()", eventReceived.getValue());
+        assertEquals("mvel: new com.rewardsystem.MyRewardsHandler()", eventReceived.getValue());
 
         // nake sure the correct wid maven dependencies got installed into the pom
         assertNotNull(projectPOM);
         assertNotNull(projectPOM.getDependencies());
-        assertEquals(2, projectPOM.getDependencies().size());
+        assertEquals(3, projectPOM.getDependencies().size());
         Dependencies pomDepends = projectPOM.getDependencies();
 
         Dependency depends1 = pomDepends.get(0);
@@ -221,7 +228,95 @@ public class ServiceRepoUtilsTest extends RepositoryBaseTest {
         assertEquals("systemhelper", depends2.getArtifactId());
         assertEquals("1.2", depends2.getVersion());
 
+        Dependency depends3 = pomDepends.get(2);
+        assertNotNull(depends3);
+        assertEquals("com.sample.demo", depends3.getGroupId());
+        assertEquals("demo-test", depends3.getArtifactId());
+        assertEquals("1.2.3", depends3.getVersion());
+        assertEquals("test", depends3.getScope());
+    }
 
+    @Test
+    public void testInstallTwiceTheSameWorkItem() throws Exception {
+
+        Map<String, WorkDefinitionImpl> workitemsFromRepo = WorkItemRepository.getWorkDefinitions(getClass().getResource("servicerepo").toURI().toString());
+
+        Collection<Asset> wids = repository.listAssetsRecursively("/", new FilterByExtension("wid"));
+        assertEquals(0, wids.size());
+
+        Collection<Asset> pngs = repository.listAssetsRecursively("/", new FilterByExtension("png"));
+        assertEquals(0, pngs.size());
+
+        ServiceRepoUtils.installWorkItem(workitemsFromRepo,
+                "MicrosoftAcademy",
+                uuid,
+                repository,
+                vfsServices,
+                widinstall,
+                notification,
+                pomService,
+                projectService,
+                metadataService);
+
+        ServiceRepoUtils.installWorkItem(workitemsFromRepo,
+                "MicrosoftAcademy",
+                uuid,
+                repository,
+                vfsServices,
+                widinstall,
+                notification,
+                pomService,
+                projectService,
+                metadataService);
+
+        assertEquals(2, receivedWidInstallEvents.size());
+        // make sure the event content is valid
+        Object event = receivedWidInstallEvents.get(0);
+        assertTrue(event instanceof DesignerWorkitemInstalledEvent);
+        DesignerWorkitemInstalledEvent eventReceived = (DesignerWorkitemInstalledEvent) event;
+        assertEquals("MicrosoftAcademy", eventReceived.getName());
+        assertEquals("mvel: new org.msho.app.MicrosoftAcademyWorkItemHandler()", eventReceived.getValue());
+
+        // nake sure the correct wid maven dependencies got installed into the pom
+        assertNotNull(projectPOM);
+        assertNotNull(projectPOM.getDependencies());
+        assertEquals(1, projectPOM.getDependencies().size());
+        Dependencies pomDepends = projectPOM.getDependencies();
+
+        Dependency depends1 = pomDepends.get(0);
+        assertNotNull(depends1);
+        assertEquals("com.microsoft", depends1.getGroupId());
+        assertEquals("microsoftacademy", depends1.getArtifactId());
+        assertEquals("1.0", depends1.getVersion());
+
+        wids = repository.listAssetsRecursively("/", new FilterByExtension("wid"));
+        assertEquals(1, wids.size());
+
+        pngs = repository.listAssetsRecursively("/", new FilterByExtension("png"));
+        assertEquals(1, pngs.size());
+
+        verify(notification, never()).fire(any(NotificationEvent.class));
+    }
+
+    @Test
+    public void testInstallMinimalisticWorkItem() throws Exception {
+
+        Map<String, WorkDefinitionImpl> workitemsFromRepo = WorkItemRepository.getWorkDefinitions(getClass().getResource("servicerepo").toURI().toString());
+
+        ServiceRepoUtils.installWorkItem(workitemsFromRepo,
+                "Minimalistic",
+                uuid,
+                repository,
+                vfsServices,
+                widinstall,
+                notification,
+                pomService,
+                projectService,
+                metadataService);
+
+        assertEquals(0, receivedWidInstallEvents.size());
+        verify(notification).fire(notificationCaptor.capture());
+        assertEquals("Installed workitem cannot be registered in project configuration.", notificationCaptor.getValue().getNotification());
     }
 
 }

--- a/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/MicrosoftAcademy/MicrosoftAcademy.wid
+++ b/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/MicrosoftAcademy/MicrosoftAcademy.wid
@@ -13,7 +13,7 @@ import org.drools.core.process.core.datatype.impl.type.ObjectDataType;
     "displayName" : "Microsoft Academy",
     "icon" : "microsoftacademy.png",
     "category" : "Search",
-    "defaultHandler" : "mvel: org.msho.app.MicrosoftAcademyWorkItemHandler()",
+    "defaultHandler" : "mvel: new org.msho.app.MicrosoftAcademyWorkItemHandler()",
     "documentation" : "index.html",
     "dependencies": [
 

--- a/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/Minimalistic/Minimalistic.wid
+++ b/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/Minimalistic/Minimalistic.wid
@@ -1,0 +1,25 @@
+import org.drools.core.process.core.datatype.impl.type.StringDataType;
+import org.drools.core.process.core.datatype.impl.type.ObjectDataType;
+
+[
+  [
+    "name" : "Minimalistic",
+    "parameters" : [
+      "title" : new StringDataType()
+    ], 
+ 	"results" : [ 
+    	   "searchresults" : new ObjectDataType("java.util.Map")
+  	], 
+    "displayName" : "",
+    "icon" : "",
+    "category" : "",
+    "defaultHandler" : "",
+    "documentation" : "",
+    "dependencies": [
+
+    ],
+    "mavenDependencies" : [ 
+
+    ]
+  ]
+]

--- a/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/Rewardsystem/Rewardsystem.wid
+++ b/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/Rewardsystem/Rewardsystem.wid
@@ -11,14 +11,15 @@ import org.drools.core.process.core.datatype.impl.type.StringDataType;
         "amount" : new StringDataType() 
     ],
     "displayName" : "Rewardsystem",
-    "defaultHandler": "mvel: com.rewardsystem.MyRewardsHandler()",
+    "defaultHandler": "mvel: new com.rewardsystem.MyRewardsHandler()",
     "category" : "Rewards",
     "dependencies": [
 
     ],
     "mavenDependencies" : [ 
 	"com.rewardssystem:myrewardssystem:2.0",
-        "com.rewardssystem:systemhelper:1.2"
+        "com.rewardssystem:systemhelper:1.2",
+        "com.sample.demo:demo-test:1.2.3:test"
     ]
   ]
 

--- a/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/SwitchYardService/SwitchYardService.wid
+++ b/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/SwitchYardService/SwitchYardService.wid
@@ -10,7 +10,7 @@ import org.drools.core.process.core.datatype.impl.type.StringDataType;
         "displayName" : "SwitchYard Service",
         "icon" : "switchyard.gif",
         "category": "Integration",
-	"defaultHandler": "reflection: com.switchyard.SwitchYardHandler",
+	"defaultHandler": "reflection: new com.switchyard.SwitchYardHandler",
 	"dependencies": [
 
     	],

--- a/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/index.conf
+++ b/jbpm-designer-backend/src/test/resources/org/jbpm/designer/web/server/servicerepo/index.conf
@@ -2,3 +2,4 @@ MicrosoftAcademy
 SwitchYardService
 Rewardsystem
 InvalidService
+Minimalistic


### PR DESCRIPTION
This PR adds tests for automatic WID import feature.

Next 3 main changes of this PR are:

1. Injection of services needed to change pom.xml and DD was moved to lower level in the architecture. As consequence of this some interfaces are now more simple.

2. There is added try-catch block in the JbpmPreprocessingUnit class. This try-catch block ensures that installation of WIDs will continue even if the installation of some WID failed.

3. There is replaced method `deleteAsset` with the method `deleteAssetFromPath`. The method `deleteAsset` was not working and was returning `false` as information about not successful deletion. As consequence of the method replacement, the user will not more see the message, that the WorkItem is already installed. Instead of this the old *.wid file will be overwritten withe new one. Also the icon will be overwritten if the new wid references the same icon.