### PR TITLE
Decrease the number of GWT workers

### DIFF
--- a/jbpm-designer-standalone/pom.xml
+++ b/jbpm-designer-standalone/pom.xml
@@ -947,7 +947,7 @@
         </property>
       </activation>
       <properties>
-        <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
+        <gwt.compiler.localWorkers>2</gwt.compiler.localWorkers>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
 * the project should sucessfullly compile
   on a machine with 8GB RAM (even that can be
   seen as quite a lot). Running 4 parallel
   workers on 8GB resulted in OOMEs.