### PR TITLE
JBPM-5315 RHBPMS-4251 Removed usage of IOUtils.closeQuietly when closing Scanner instance.

### DIFF
--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnit.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnit.java
@@ -803,7 +803,7 @@ public class JbpmPreprocessingUnit implements IDiagramPreprocessingUnit {
             }
             return fileContents.toString();
         } finally {
-            IOUtils.closeQuietly(scanner);
+            scanner.close();
         }
     }
 


### PR DESCRIPTION
- Substituted use of IOUtils.closeQuietly with scanner.close() so it works on JDK 1.6. 

No master PR, because jdk 1.6 currently not relevant there. 