### PR TITLE
Webapp fix after inclusion of kie-wb-common-library

### DIFF
--- a/jbpm-designer-standalone/pom.xml
+++ b/jbpm-designer-standalone/pom.xml
@@ -510,6 +510,20 @@
       <artifactId>kie-wb-common-forms-bpmn-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-library-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-library-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-library-backend</artifactId>
+    </dependency>
+
     <!-- formModeler dependencies -->
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -783,6 +797,8 @@
             <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-workbench-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-server-ui-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-server-ui-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-library-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-library-api</compileSourcesArtifact>
 
             <!-- KIE UberFire extensions -->
             <compileSourcesArtifact>org.kie.uberfire:kie-uberfire-social-activities-api</compileSourcesArtifact>

--- a/jbpm-designer-standalone/src/main/resources/org/jbpm/designer/jBPMDesigner.gwt.xml
+++ b/jbpm-designer-standalone/src/main/resources/org/jbpm/designer/jBPMDesigner.gwt.xml
@@ -41,6 +41,7 @@
   <inherits name="org.kie.workbench.common.screens.datamodeller.KieWorkbenchDatamodellerClient"/>
   <inherits name="org.drools.workbench.screens.workitems.DroolsWorkbenchWorkItemsEditorClient"/>
   <inherits name="org.kie.workbench.common.screens.defaulteditor.DroolsWorkbenchDefaultEditorClient"/>
+  <inherits name="org.kie.workbench.common.screens.library.LibraryClient"/>
 
   <!-- Common Services -->
   <inherits name="org.kie.workbench.common.widgets.KieWorkbenchWidgetsCommon"/>


### PR DESCRIPTION
The compilation and gwt build was fixed, but when `mvn clean gwt:run` is runned, I get this error: https://gist.github.com/paulovmr/46ec2d3b12bf0f4457df6ad51fdfb4f5

Can anyone take a look at that? Opening the PR anyway, because this fixes the build.