### PR TITLE
Removing provided from social dependency api (sdm runtime issue)

### DIFF
--- a/jbpm-designer-standalone/pom.xml
+++ b/jbpm-designer-standalone/pom.xml
@@ -176,7 +176,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-social-activities-api</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fix a social related error in SDM. But I still see other non related issue: https://gist.github.com/ederign/af205213461d6108dadb271303b2855f